### PR TITLE
Persistence fixes for handwear and headgear

### DIFF
--- a/Prefabs/Characters/Core/Handwear_Base.et
+++ b/Prefabs/Characters/Core/Handwear_Base.et
@@ -1,0 +1,9 @@
+GameEntity {
+ ID "5DF2774398EBD275"
+ components {
+  EPF_PersistenceComponent "{64674A541590739B}" {
+   m_pSaveData EPF_ItemSaveDataClass "{64674A541112DE12}" {
+   }
+  }
+ }
+}

--- a/Prefabs/Characters/Core/Handwear_Base.et.meta
+++ b/Prefabs/Characters/Core/Handwear_Base.et.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{164E9CC16035195E}Prefabs/Characters/Core/Handwear_Base.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/Prefabs/Characters/Core/Headgear_Base.et
+++ b/Prefabs/Characters/Core/Headgear_Base.et
@@ -1,0 +1,13 @@
+GameEntity {
+ ID "5112706CD4157AC7"
+ components {
+  EPF_PersistenceComponent "{5A28749C3DBDF202}" {
+   m_pSaveData EPF_ItemSaveDataClass "{5A28749C3A6302DE}" {
+    m_aComponents {
+     EPF_BaseInventoryStorageComponentSaveDataClass "{64674A54F14E88C9}" {
+     }
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Characters/Core/Headgear_Base.et.meta
+++ b/Prefabs/Characters/Core/Headgear_Base.et.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{17F335BF60DD2550}Prefabs/Characters/Core/Headgear_Base.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}


### PR DESCRIPTION
-Added Persistence component to Handwear_Base.et. Gloves will now be saved.
-Added and enabled BaseInventoryStorageSavedataClass on Headgear_Base.et. RHS helmets should now save any attachments inside them.